### PR TITLE
fix 403 error

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -36,7 +36,7 @@
 				return m.request({ method: 'GET', url: baseURL + '/domain/'+DOMAIN+'/schema', headers: getHeaders()})
 			},
 			reason: function(values) {
-				return m.request({ method: 'POST', url: baseURL + '/domain/'+DOMAIN+'/reasoning/reason?criteria=draft&known-results-only', data: values, headers: getHeaders()})
+				return m.request({ method: 'POST', url: baseURL + '/domain/'+DOMAIN+'/reasoning/reason?criteria=draft', data: values, headers: getHeaders()})
 			}
 		}
 	})();


### PR DESCRIPTION
I'm not entirely sure this is correct, but I found that removing the `&known-results-only` would fix the example request from always generating a 403 error.